### PR TITLE
Include hidden files when loading the dataset

### DIFF
--- a/hello_wordsmith/datastores.py
+++ b/hello_wordsmith/datastores.py
@@ -38,7 +38,7 @@ def fetch_or_initialise_datastores() -> InitialisedDataContainer:
         package_directory = os.path.dirname(os.path.abspath(__file__))
         dataset_path = os.path.join(package_directory, "public_wordsmith_dataset")
         docs = SimpleDirectoryReader(
-            input_dir=dataset_path, filename_as_id=True
+            input_dir=dataset_path, filename_as_id=True, exclude_hidden=False
         ).load_data()
         docstore.add_documents(docs)
         index = VectorStoreIndex.from_documents(


### PR DESCRIPTION
It's common to create the virtualenv in `.venv`. `SimpleDirectoryReader` by default ignores files in hidden directories (where part of the path starts with `.`).

This leads to the following error:

    ❯ hello-wordsmith
    ..
    Traceback (most recent call last):
    ..
      File "/Users/igor/src/rag101/.venv/lib/python3.9/site-packages/llama_index/core/readers/file/base.py", line 305, in _add_files
        raise ValueError(f"No files found in {input_dir}.")
    ValueError: No files found in /Users/igor/src/rag101/.venv/lib/python3.9/site-packages/hello_wordsmith/public_wordsmith_dataset.

Even though:

    ❯ ls /Users/igor/src/rag101/.venv/lib/python3.9/site-packages/hello_wordsmith/public_wordsmith_dataset
    us_constitution.txt